### PR TITLE
Add formatter that works with write-in-chunks

### DIFF
--- a/pg2kinesis/__main__.py
+++ b/pg2kinesis/__main__.py
@@ -25,7 +25,7 @@ from .log import logger
 @click.option('--stream-name', '-k', default='pg2kinesis',
               help='Kinesis stream name.')
 @click.option('--message-formatter', '-f', default='CSVPayload',
-              type=click.Choice(['CSVPayload', 'CSV', 'JSONLine', 'ChunkJSONLine']),
+              type=click.Choice(['CSVPayload', 'CSV', 'JSONLine']),
               help='Kinesis record formatter.')
 @click.option('--table-pat', help='Optional regular expression for table names.')
 @click.option('--full-change', default=False, is_flag=True,

--- a/pg2kinesis/formatter.py
+++ b/pg2kinesis/formatter.py
@@ -178,8 +178,13 @@ class ChunkJSONLineFormatter(JSONLineFormatter):
         Takes a chunk of a changeset which can look like:
 
         1. b'{"xid": "1111", "timestamp": "...", "change": ['
-        2. b'{"kind": "...", ...}' or b',{"kind": "...", ...}'
-        3. b']}'
+        2. b'{"kind": "...", ...}'
+        3. b',{"kind": "...", ...}'
+        4. b']}'
+
+        Related:
+        https://github.com/eulerto/wal2json/issues/84
+        https://github.com/eulerto/wal2json/issues/46
 
         :param change: a message payload chunk from postgres wal2json plugin.
         :return: A list of type FullChange (Change not yet supported)
@@ -194,6 +199,7 @@ class ChunkJSONLineFormatter(JSONLineFormatter):
             change = json.loads(change)
             self.cur_xact = change['xid']
             self.cur_timestamp = change['timestamp']
+            logger.info('New payload %s', self.cur_xact)
         elif self.cur_xact and change.startswith(b'{'):
             # this is the first change chunk in a full changeset
             # we should also already have the cur_xact data from a previous iteration

--- a/pg2kinesis/formatter.py
+++ b/pg2kinesis/formatter.py
@@ -204,7 +204,7 @@ class ChunkJSONLineFormatter(JSONLineFormatter):
             change = json.loads(change)
             self.cur_xact = change['xid']
             self.cur_timestamp = change['timestamp']
-            logger.info('New payload %s', self.cur_xact)
+            logger.info('Start of transaction %s', self.cur_xact)
         elif change.startswith(b'{'):
             # this is the first change chunk in a full changeset
             # we should also already have the cur_xact data from a previous iteration
@@ -221,6 +221,7 @@ class ChunkJSONLineFormatter(JSONLineFormatter):
         elif change == b']}':
             # this is the end of a changeset
             # discard it and clear the metadata
+            logger.info('End of transaction %s', self.cur_xact)
             self.cur_xact = ''
             self.cur_timestamp = ''
 

--- a/pg2kinesis/log.py
+++ b/pg2kinesis/log.py
@@ -3,5 +3,5 @@ import logging
 
 FORMAT = '%(asctime)-15s %(levelname)s %(message)s'
 logging.basicConfig(format=FORMAT)
-logger = logging.getLogger()
+logger = logging.getLogger('pg2kinesis')
 logger.setLevel(os.getenv('PG2KINESIS_LOG_LEVEL', logging.INFO))

--- a/pg2kinesis/slot.py
+++ b/pg2kinesis/slot.py
@@ -38,7 +38,7 @@ class SlotReader(object):
     """
 
     def __init__(self, database, host, port, user, sslmode, slot_name,
-                 output_plugin='test_decoding'):
+                 output_plugin='test_decoding', wal2json_write_in_chunks=False):
         # Cool fact: using connections as context manager doesn't close them on
         # success after leaving with block
         self._db_confg = dict(database=database, host=host, port=port, user=user, sslmode=sslmode)
@@ -48,6 +48,7 @@ class SlotReader(object):
         self._normal_conn = None
         self.slot_name = slot_name
         self.output_plugin = output_plugin
+        self.wal2json_write_in_chunks = wal2json_write_in_chunks
         self.cur_lag = 0
 
     def __enter__(self):
@@ -135,6 +136,8 @@ class SlotReader(object):
     def process_replication_stream(self, consume):
         if self.output_plugin == 'wal2json':
             options = {'include-xids': 1, 'include-timestamp': 1}
+            if self.wal2json_write_in_chunks:
+                options['write-in-chunks'] = 1
         else:
             options = None
         logger.info('Output plugin options: "%s"' % options)

--- a/tests/test_chunk_formatter.py
+++ b/tests/test_chunk_formatter.py
@@ -78,3 +78,33 @@ def test__preprocess_wal2json_full_change(formatter):
                             "columnvalues": ["00079f3e-0479-4475-acff-4f225cc5188a"]
                         }
                 """)
+
+    # invalid states
+    formatter.cur_xact = 100
+    formatter.full_change = True
+    with pytest.raises(ValueError) as e:
+        formatter._preprocess_wal2json_change(b"""{"xid": 101,
+                "timestamp": "2019-09-04 01:27:59.195339+00",
+                "change": [""")
+
+    formatter.cur_xact = ''
+    with pytest.raises(ValueError) as e:
+        formatter._preprocess_wal2json_change(b"""{
+                        "kind": "insert",
+                        "schema": "public",
+                        "table": "test_table",
+                        "columnnames": ["uuid"],
+                        "columntypes": ["int4"],
+                        "columnvalues": ["00079f3e-0479-4475-acff-4f225cc5188a"]
+                    }
+            """)
+
+        formatter._preprocess_wal2json_change(b""",{
+                        "kind": "insert",
+                        "schema": "public",
+                        "table": "test_table",
+                        "columnnames": ["uuid"],
+                        "columntypes": ["int4"],
+                        "columnvalues": ["00079f3e-0479-4475-acff-4f225cc5188a"]
+                    }
+            """)

--- a/tests/test_chunk_formatter.py
+++ b/tests/test_chunk_formatter.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+from __future__ import unicode_literals
+import json
+
+import mock
+import pytest
+
+from pg2kinesis.slot import PrimaryKeyMapItem
+from pg2kinesis.formatter import Change, ChunkJSONLineFormatter
+
+@pytest.fixture
+def pkey_map():
+    return {'public.test_table': PrimaryKeyMapItem(u'public.test_table', u'uuid', u'uuid', 0),
+            'public.test_table2': PrimaryKeyMapItem(u'public.test_table2', u'name', u'character varying', 0)}
+
+@pytest.fixture(params=[ChunkJSONLineFormatter])
+def formatter(request, pkey_map):
+    return request.param(pkey_map)
+
+
+def test__preprocess_wal2json_full_change(formatter):
+    formatter.cur_xact = ''
+    formatter.cur_timestamp = ''
+    formatter.full_change = True
+
+    # 1st chunk, setting metadata
+    result = formatter._preprocess_wal2json_change(b"""{"xid": 101,
+                "timestamp": "2019-09-04 01:27:59.195339+00",
+                "change": [""")
+    assert result == []
+    assert formatter.cur_xact == 101
+    assert formatter.cur_timestamp == '2019-09-04 01:27:59.195339+00'
+
+    # 2nd chunk
+    change = formatter._preprocess_wal2json_change(b"""{
+                        "kind": "insert",
+                        "schema": "public",
+                        "table": "test_table",
+                        "columnnames": ["uuid"],
+                        "columntypes": ["int4"],
+                        "columnvalues": ["00079f3e-0479-4475-acff-4f225cc5188a"]
+                    }
+            """)[0]
+    assert change.xid == 101
+    assert change.change['kind'] == 'insert'
+    assert change.change['columnvalues'] == ['00079f3e-0479-4475-acff-4f225cc5188a']
+
+    # 3rd chunk
+    change = formatter._preprocess_wal2json_change(b""",{
+                        "kind": "insert",
+                        "schema": "public",
+                        "table": "test_table",
+                        "columnnames": ["uuid"],
+                        "columntypes": ["int4"],
+                        "columnvalues": ["00079f3e-0479-4475-acff-4f225cc5188a"]
+                    }
+            """)[0]
+    assert change.xid == 101
+    assert change.change['kind'] == 'insert'
+    assert change.change['columnvalues'] == ['00079f3e-0479-4475-acff-4f225cc5188a']
+
+    # closing chunk
+    result = formatter._preprocess_wal2json_change(b"]}")
+    assert result == []
+    assert formatter.cur_xact == ''
+    assert formatter.cur_timestamp == ''
+
+    # only full_change is supported
+    formatter.cur_xact = 101
+    formatter.full_change = False
+    with pytest.raises(ValueError) as e:
+        formatter._preprocess_wal2json_change(b"""{
+                            "kind": "insert",
+                            "schema": "public",
+                            "table": "test_table",
+                            "columnnames": ["uuid"],
+                            "columntypes": ["int4"],
+                            "columnvalues": ["00079f3e-0479-4475-acff-4f225cc5188a"]
+                        }
+                """)

--- a/tests/test_chunk_formatter.py
+++ b/tests/test_chunk_formatter.py
@@ -30,6 +30,7 @@ def test__preprocess_wal2json_full_change(formatter):
     assert result == []
     assert formatter.cur_xact == 101
     assert formatter.cur_timestamp == '2019-09-04 01:27:59.195339+00'
+    assert formatter.transaction_change_count == 0
 
     # 2nd chunk
     change = formatter._preprocess_wal2json_change(b"""{
@@ -44,6 +45,7 @@ def test__preprocess_wal2json_full_change(formatter):
     assert change.xid == 101
     assert change.change['kind'] == 'insert'
     assert change.change['columnvalues'] == ['00079f3e-0479-4475-acff-4f225cc5188a']
+    assert formatter.transaction_change_count == 1
 
     # 3rd chunk
     change = formatter._preprocess_wal2json_change(b""",{
@@ -58,12 +60,14 @@ def test__preprocess_wal2json_full_change(formatter):
     assert change.xid == 101
     assert change.change['kind'] == 'insert'
     assert change.change['columnvalues'] == ['00079f3e-0479-4475-acff-4f225cc5188a']
+    assert formatter.transaction_change_count == 2
 
     # closing chunk
     result = formatter._preprocess_wal2json_change(b"]}")
     assert result == []
     assert formatter.cur_xact == ''
     assert formatter.cur_timestamp == ''
+    assert formatter.transaction_change_count == 0
 
     # only full_change is supported
     formatter.cur_xact = 101

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -6,7 +6,7 @@ import mock
 import pytest
 
 from pg2kinesis.slot import PrimaryKeyMapItem
-from pg2kinesis.formatter import Change, CSVFormatter, CSVPayloadFormatter, Formatter, get_formatter
+from pg2kinesis.formatter import Change, CSVFormatter, CSVPayloadFormatter, JSONLineFormatter, Formatter, get_formatter
 
 
 def get_formatter_produce_formatted_message(cls):
@@ -29,6 +29,10 @@ def test_CSVPayloadFormatter_produce_formatted_message():
     payload = result.fmt_msg.split(',', 2)[-1]
     assert json.loads(payload) == dict(xid=1, table=u'public.blue', operation=u'Update', pkey=u'123456')
 
+def test_JSONLineFormatter_produce_formatted_message():
+    result = get_formatter_produce_formatted_message(JSONLineFormatter)
+    payload = result.fmt_msg
+    assert json.loads(payload) == dict(xid=1, table=u'public.blue', operation=u'Update', pkey=u'123456')
 
 @pytest.fixture
 def pkey_map():
@@ -36,7 +40,7 @@ def pkey_map():
             'public.test_table2': PrimaryKeyMapItem(u'public.test_table2', u'name', u'character varying', 0)}
 
 
-@pytest.fixture(params=[CSVFormatter, CSVPayloadFormatter, Formatter])
+@pytest.fixture(params=[CSVFormatter, CSVPayloadFormatter, JSONLineFormatter, Formatter])
 def formatter(request, pkey_map):
     return request.param(pkey_map)
 


### PR DESCRIPTION
https://pushpay.atlassian.net/browse/PP-????

- [ ] Locally Pair Tested


The ChunkJSONLineFormatter supports the payload format received from wal2json with the `--write-in-chunks` flag enabled. The flag tells wal2json to send each individual change as its own payload to the consumer. So instead of one JSON payload of one transaction with 100 changes, it will send ~100 JSON payloads for each change. It is up to the consumer to properly parse and reconstruct the full transaction changeset.

Each payload chunk received is an incomplete/invalid JSON string that needs to be coerced by the formatter before being consumed by the writer.