### PR TITLE
PP-35481 Pass filter-tables parameter to wal2json

### DIFF
--- a/pg2kinesis/slot.py
+++ b/pg2kinesis/slot.py
@@ -38,7 +38,7 @@ class SlotReader(object):
     """
 
     def __init__(self, database, host, port, user, sslmode, slot_name,
-                 output_plugin='test_decoding', wal2json_write_in_chunks=False):
+                 output_plugin='test_decoding', wal2json_write_in_chunks=False, wal2json_filter_tables=''):
         # Cool fact: using connections as context manager doesn't close them on
         # success after leaving with block
         self._db_confg = dict(database=database, host=host, port=port, user=user, sslmode=sslmode)
@@ -49,6 +49,7 @@ class SlotReader(object):
         self.slot_name = slot_name
         self.output_plugin = output_plugin
         self.wal2json_write_in_chunks = wal2json_write_in_chunks
+        self.wal2json_filter_tables = wal2json_filter_tables
         self.cur_lag = 0
 
     def __enter__(self):
@@ -138,6 +139,8 @@ class SlotReader(object):
             options = {'include-xids': 1, 'include-timestamp': 1}
             if self.wal2json_write_in_chunks:
                 options['write-in-chunks'] = 1
+            if self.wal2json_filter_tables:
+                options['filter-tables'] = self.wal2json_filter_tables
         else:
             options = None
         logger.info('Output plugin options: "%s"' % options)


### PR DESCRIPTION
https://pushpay.atlassian.net/browse/PP-35481

- [ ] Locally Pair Tested


> `filter-tables`: exclude rows from the specified tables. Default is empty which means that no table will be filtered. It is a comma separated value. The tables should be schema-qualified. `*.foo` means table foo in all schemas and `bar.*` means all tables in schema bar. Special characters (space, single quote, comma, period, asterisk) must be escaped with backslash. Schema and table are case-sensitive. Table `"public"."Foo bar"` should be specified as `public.Foo\ bar`.

The plan is to specify `--wal2json-filter-tables=repack.*` to exclude the temporary tables created by pg_repack