### PR TITLE
SRE-10108 Skip wal2json logical decoding messages in ChunkJSONLineFormatter

### DIFF
--- a/pg2kinesis/formatter.py
+++ b/pg2kinesis/formatter.py
@@ -210,6 +210,14 @@ class ChunkJSONLineFormatter(JSONLineFormatter):
             self.cur_xact = change['xid']
             self.cur_timestamp = change['timestamp']
             logger.debug('Start of transaction %s (%s)', self.cur_xact, self.cur_timestamp)
+        elif change.startswith(b'{"change":'):
+            # a non-transactional logical decoding message (e.g. a Debezium
+            # heartbeat). These are written to the WAL by pg_logical_emit_message
+            # and decoded by every slot on the database, so they appear here even
+            # though they are not ours. They have no xid or transaction framing,
+            # so discard them.
+            logger.debug('Skipping non-transactional message')
+            return []
         elif change.startswith(b'{'):
             # this is the first change chunk in a full changeset
             # we should also already have the cur_xact data from a previous iteration
@@ -233,10 +241,14 @@ class ChunkJSONLineFormatter(JSONLineFormatter):
             self.cur_timestamp = ''
             self.transaction_change_count = 0
 
-        if change_dictionary and self.table_re.search(change_dictionary['table']):
-            return [FullChange(xid=self.cur_xact, timestamp=self.cur_timestamp, change=change_dictionary)]
-        else:
-            return []
+        if change_dictionary:
+            if change_dictionary.get('kind') == 'message':
+                # a transactional logical decoding message; it has no table, skip it
+                logger.debug('Skipping transactional message')
+                return []
+            if self.table_re.search(change_dictionary['table']):
+                return [FullChange(xid=self.cur_xact, timestamp=self.cur_timestamp, change=change_dictionary)]
+        return []
 
 
 def get_formatter(name, primary_key_map, output_plugin, full_change, table_pat):

--- a/tests/test_chunk_formatter.py
+++ b/tests/test_chunk_formatter.py
@@ -112,3 +112,38 @@ def test__preprocess_wal2json_full_change(formatter):
                         "columnvalues": ["00079f3e-0479-4475-acff-4f225cc5188a"]
                     }
             """)
+
+
+def test__preprocess_wal2json_skips_non_transactional_message(formatter):
+    # Non-transactional logical decoding messages (e.g. Debezium heartbeats) are
+    # written to the WAL by pg_logical_emit_message and decoded by every slot on
+    # the database, so they turn up here with no xid and no transaction framing.
+    formatter.cur_xact = ''
+    formatter.cur_timestamp = ''
+    formatter.full_change = True
+
+    result = formatter._preprocess_wal2json_change(
+        b'{"change":[{"kind":"message","transactional":false,'
+        b'"prefix":"debezium-heartbeat","content":"2026-06-02 23:40:00"}]}')
+
+    assert result == []
+    assert formatter.cur_xact == ''
+    assert formatter.cur_timestamp == ''
+
+
+def test__preprocess_wal2json_skips_transactional_message(formatter):
+    # A transactional message arrives inside normal transaction framing but has
+    # no table, so it must be skipped rather than blowing up on a missing key.
+    formatter.cur_xact = ''
+    formatter.cur_timestamp = ''
+    formatter.full_change = True
+
+    formatter._preprocess_wal2json_change(
+        b'{"xid": 202, "timestamp": "2026-06-02 23:40:00+00", "change": [')
+
+    result = formatter._preprocess_wal2json_change(
+        b'{"kind":"message","transactional":true,'
+        b'"prefix":"some-prefix","content":"hello"}')
+
+    assert result == []
+    assert formatter.cur_xact == 202


### PR DESCRIPTION
These messages are tripping up the parser. It coincides with when we turned on Debezium for Community. Skip these type of message entirely, they are not useful for CDC.

Medium to long term, we should get rid of pg2kinesis and use Debezium instead.

<img width="768" height="541" alt="image" src="https://github.com/user-attachments/assets/f261c189-6e9d-4f5c-bb67-9dad18a7fa20" />

```
 SELECT lsn, xid, left(data, 100) AS chunk
  FROM pg_logical_slot_peek_changes(
      'pg2kinesis_community', NULL, NULL,
      'include-xids', '1',
      'include-timestamp', '1',
      'write-in-chunks', '1'
  )
  LIMIT 30;
```